### PR TITLE
Removed source files to keep image compact

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,7 @@ RUN apt-get update  \
     && /sbin/ldconfig \
 #clean up
     && rm -rf /tmp/* \
+    && rm -rf /opt/vc/src \
     && apt-get remove git curl \
     && apt-get -yqq autoremove \
     && apt-get -y clean \


### PR DESCRIPTION
The image used as the base for many developers, it would be great to keep it as small as possible. The firmware inside is waste of space.

You may consider either have two tags (-base and -dev) without/with sources or just remove it.

Thank you for consideration.